### PR TITLE
Fixed links to be the same size as the images

### DIFF
--- a/_sass/_components--brands.scss
+++ b/_sass/_components--brands.scss
@@ -3,9 +3,9 @@ $size--brands-per-row-tablet:     3;
 $size--brand-width:               100% / $size--brands-per-row;
 $size--brand-width-tablet:        100% / $size--brands-per-row-tablet;
 $size--brand-width-small:         100%;
-$size--image-width:               70%;
-$size--image-width-tablet:        80%;
-$size--image-width-small:         40%;
+$size--item-width:               70%;
+$size--item-width-tablet:        80%;
+$size--item-width-small:         40%;
 
 .site-brands-container {
   background-color: $hint-of-red;
@@ -31,11 +31,14 @@ $size--image-width-small:         40%;
     width: $size--brand-width;
 
     a {
+      display: block;
+      width: $size--item-width;
+      margin: 0 auto;
       cursor: pointer;
     }
 
     img {
-      width: $size--image-width;
+      width: 100%;
       display: block;
       margin: 0 auto;
     }
@@ -45,8 +48,8 @@ $size--image-width-small:         40%;
     li {
       width: $size--brand-width;
 
-      img {
-        width: $size--image-width-tablet;
+      a {
+        width: $size--item-width-tablet;
       }
     }
   }
@@ -55,9 +58,8 @@ $size--image-width-small:         40%;
     li {
       width: $size--brand-width-small;
 
-      img {
-        margin: 0 auto;
-        width: $size--image-width-small;
+      a {
+        width: $size--item-width-small;
       }
 
       & + li {

--- a/_sass/_components--footer.scss
+++ b/_sass/_components--footer.scss
@@ -77,7 +77,6 @@ $size--title-font-size:               1.1rem;
     // This is the logo image size to match the
     // header logo.
     width: $size--logo-width;
-    height: $size--logo-height;
   }
 
   @media #{$just-small-resolutions} {

--- a/_sass/_settings--defaults.scss
+++ b/_sass/_settings--defaults.scss
@@ -63,4 +63,3 @@
   $from-small-to-medium-resolutions:        "only screen and (min-width: #{$bootstrap-sm}) and (max-width: #{$bootstrap-md})";
 
   $size--logo-width: 44px;
-  $size--logo-height: 44px;


### PR DESCRIPTION
# Context

Links on the brands section were clickable outside of the image bounds and it needed to be fixed, so styles for that section were modified. Also made sure any image only gets width OR height modified. 

This PR closes #28.

## Media

![overflow](https://cloud.githubusercontent.com/assets/11748696/23932924/5e3c2254-0911-11e7-9816-a3e5a09d94e8.gif)