### PR TITLE
Mobile nav links close menu when clicked

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -35,7 +35,7 @@
 
     </div>
   </header>
-  
+
 </nav>
 
 <div id="mobile-nav" class="site-nav-mobile-wrapper">
@@ -44,7 +44,7 @@
 
       {% for link in section.menus %}
         <li class="site-nav-mobile-link">
-          <a href="{{link.href}}">{{link.name}}</a>
+          <a class="nav-mobile-link" href="{{link.href}}">{{link.name}}</a>
         </li>
       {% endfor %}
 

--- a/_sass/_components--navbar.scss
+++ b/_sass/_components--navbar.scss
@@ -20,8 +20,7 @@ $size--header-title-margin-top: 24px;
   z-index: z('navbar');
   width: 100%;
   position: fixed;
-  opacity: 1;
-  transition: all .3s ease;
+  transition: all .4s ease-in-out;
 
   // Using headroom.js for scrolling menu effect
   &.headroom {

--- a/js/main.js
+++ b/js/main.js
@@ -1,9 +1,10 @@
 $(document).ready(function () {
-  var mobileMenu = $('#mobile-nav');
-  var siteNav = $('.site-navbar');
+  var mobileMenuElements = $('#mobile-nav, .site-navbar, #mobile-nav-toggle');
   var mobileMenuToggle = $('#mobile-nav-toggle');
-  var toggleEl = $('.menu-toggle');
+  var mobileNavLinks = $('.nav-mobile-link');
+  var navBar = $('.site-navbar');
   var video = $('#lead-video');
+  var linkWasClicked = false;
 
   /*
     All of the videos used on the lead section, have a loop
@@ -12,7 +13,19 @@ $(document).ready(function () {
   var loopResetTime = 11;
   var videoElement = video[0];
 
-  $('.site-navbar').headroom();
+  /*
+    This makes sure headroom stays open when we click a nav link
+  */
+  $('.site-navbar').headroom({
+    onUnpin: function() {
+      $(this).toggleClass(this.classes.unpinned, !linkWasClicked);
+      $(this).toggleClass(this.classes.pinned, linkWasClicked);
+
+      linkWasClicked = false;
+
+      return false;
+    }
+  });
 
   /*
     We add a non breaking space (&nbsp;) between the last two
@@ -25,9 +38,14 @@ $(document).ready(function () {
   });
 
   mobileMenuToggle.on('click', function(event) {
-    mobileMenu.toggleClass('active');
-    siteNav.toggleClass('active');
-    toggleEl.toggleClass('active');
+    mobileMenuElements.toggleClass('active');
+  });
+
+  mobileNavLinks.on('click', function(event) {
+    event.preventDefault();
+    mobileMenuElements.removeClass('active');
+    linkWasClicked = true;
+    console.log(this.getAttribute('href'));
   });
 
   // This resets the video to the loopResetTime


### PR DESCRIPTION
# Context

Mobile Nav links were not closing the menu when clicked, so this was fixed by:

- Handling click event on Mobile Nav links to close menu.

## Links

- This was useful for passing parameters to headroom init [Blog post](https://iamsteve.me/blog/entry/stop-headroom.js-hiding-when-your-navigation-is-open).

## Media

![navbarlinks](https://cloud.githubusercontent.com/assets/11748696/24019860/2b791e52-0a70-11e7-9ce9-0b8848a43e7b.gif)
