### PR TITLE
Minor fix to mobile nav anchors

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -35,8 +35,8 @@ var HashLabs = {
 
     this.navBar.headroom({
       onUnpin: function() {
-        $(this).toggleClass(this.classes.unpinned, !that.linkWasClicked);
-        $(this).toggleClass(this.classes.pinned, that.linkWasClicked);
+        $(this.elem).toggleClass(this.classes.unpinned, !that.linkWasClicked);
+        $(this.elem).toggleClass(this.classes.pinned, that.linkWasClicked);
         that.linkWasClicked = false;
 
         return;


### PR DESCRIPTION
# Context

Just some minor changes on the main.js file, as the wrong element was getting selected with jquery.

This closes #49 