### PR TITLE
Removed video from tablet and phones site version

### DIFF
--- a/_includes/template-lead.html
+++ b/_includes/template-lead.html
@@ -4,7 +4,7 @@
     {% assign section = site.data.section-lead %}
 
     <div class="row">
-      <div class="col-xs-12 col-md-6">
+      <div class="col-xs-12 col-md-12 col-lg-6">
         <section class="section-lead">
           {% if include.title %}
             {% assign title = include.title %}
@@ -33,8 +33,9 @@
         </section>
       </div>
 
-      <div class="col-xs-12 col-md-6">
-        <div class="section-lead-video embed-responsive embed-responsive-16by9">
+      <div class="col-xs-12 col-md-6 col-lg-6">
+
+        <div class="section-lead-video embed-responsive embed-responsive-16by9 hidden-md-down">
           <video class="embed-responsive-item" id="lead-video" autoplay>
             {% if include.video %}
               {% assign video_name = include.video %}
@@ -46,6 +47,7 @@
             Your browser does not support the video tag.
           </video>
         </div>
+
       </div>
     </div>
 


### PR DESCRIPTION
# Context

HTML5 video player is not consistent yet on mobile devices, so video was removed on these devices (tablets, phones, etc...), later an image will be added on that spot.

## Links

Here are some links with info on the issue:

- [Stackoverflow question](http://stackoverflow.com/questions/20499341/html5-video-autoplay-on-mobile-browser)
- This post states that adding the 'autoplay' and 'muted' attributes should make the video work on android devices, but it depends on the device so it is not a consistent solution [Google Developers](https://developers.google.com/web/updates/2016/07/autoplay)
- [Webkit](https://webkit.org/blog/6784/new-video-policies-for-ios/)

## Media

- ![screencapture-localhost-4000-1489709233712](https://cloud.githubusercontent.com/assets/11748696/24023675/3be460bc-0a84-11e7-9811-b64ee981814e.png)
- ![screencapture-localhost-4000-1489709223990](https://cloud.githubusercontent.com/assets/11748696/24023676/3be6a12e-0a84-11e7-9abc-8f7a115cd67d.png)
