### PR TITLE
Fixed typo in FAQ section

### DIFF
--- a/_data/section-faq.yml
+++ b/_data/section-faq.yml
@@ -3,11 +3,11 @@ questions:
   - question: What's your billing model?
     answer: We bill on a monthly basis.
 
-  - question: We are your developers based?
+  - question: Where are your developers based?
     answer: Our developers are in Mexico and South America. For US clients, we will work at the same as your team. If you are not in the US, our team is trained to work in an async way, so we are still able to help you.
 
   - question: What's the shortest commitment period?
     answer: Three months. In our experience, three months is a good time for developers to adapt to your team and show its full potential.
-    
+
   - question: I don't have a team yet, can we work together?
     answer: Absolutely!. We have worked with startups being their first engineering team. Once you start hiring, we will train and mentor your hires until they can lead the development of your product.


### PR DESCRIPTION
# Context

Fixed typo in FAQ section

This closes #57 

## Media

![typo_fix](https://cloud.githubusercontent.com/assets/11748696/24067407/a59e9210-0b52-11e7-83e4-cdb98b3e3582.gif)