### PR TITLE
Added polyglot base configuration to support i18n

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,6 @@
 ---
 layout: error
-title: 404
+title: "404"
 permalink: /404.html
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## [Unreleased]
 
 ### Added
-* Bootstrap 4 as an npm dependency
+* Bootstrap 4 as an npm dependency ([@TheMightyPenguin](https://github.com/TheMightyPenguin))
+* i18n support with [polyglot](https://github.com/untra/polyglot) gem ([@TheMightyPenguin](https://github.com/TheMightyPenguin))
 
 ## [6.0] - 17/03/2017
 ### Added

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,52 @@
+# FAQ :thinking:
+
+## How do I add translated data? :globe_with_meridians:
+
+1. Add 2 data files that are named the same on `_data/en` and `_data/es`, for example `_data/en/some_page.yml` and `_data/es/some_page.yml`
+2. Add variables that are named the same to these files like so:
+
+```
+//_data/en/some_page.yml
+var: "some english variable"
+
+//_data/es/some_page.yml
+var: "una variable en español"
+```
+
+3. Use this variable on the pages like `{{ site.data.some_page.foo }}`, then the polyglot gem will automatically translate the variable depending on the site current language. Note that the en or es folder was not needed on the path to the variable.
+
+## An specific variable doesn't need translations, do I still need to add it on both language folders?
+
+No, just add it on a data file on the root of the `_data` folder and use it normally.
+
+## Should I translate URL's?
+
+No, the [polyglot] gem will automatically translate urls, so just put url's like
+these on data files/html:
+
+```
+// on html
+<a href="{{ some_data.url | prepend: site.baseurl }}"></a>
+
+// on a data file
+url: "/some_link"
+```
+
+## But I need a certain url to not get translated?
+
+Just add some extra spaces before rendering the variable like so:
+
+```
+// Will get translated
+<a href=" {{ page.url | prepend: site.baseurl }} "></a>
+
+// Won't get translated
+<a href="{{ page.url | prepend: site.baseurl }}"></a>
+```
+
+Even tho this is not documented on polyglot's docs, they use on their
+example site, specifically on a language switcher
+[here](https://github.com/untra/polyglot/blob/master/site/_includes/sidebar.html#L41)
+
+
+[polyglot]: https://github.com/untra/polyglot

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 gem 'jekyll'
 gem 'rack-jekyll'
+
+group :jekyll_plugins do
+  gem 'jekyll-polyglot', github: 'untra/polyglot'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,45 +1,65 @@
+GIT
+  remote: git://github.com/untra/polyglot.git
+  revision: 0684b07272cf2f3885f408b137e52ddd5c20a433
+  specs:
+    jekyll-polyglot (1.3.0)
+      jekyll (>= 3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
-    colorator (0.1)
-    ffi (1.9.10)
-    jekyll (3.1.2)
-      colorator (~> 0.1)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    colorator (1.1.0)
+    ffi (1.9.18)
+    forwardable-extended (2.6.0)
+    jekyll (3.5.1)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
       jekyll-sass-converter (~> 1.0)
       jekyll-watch (~> 1.1)
       kramdown (~> 1.3)
-      liquid (~> 3.0)
+      liquid (~> 4.0)
       mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
-    jekyll-sass-converter (1.4.0)
+    jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
-    jekyll-watch (1.3.1)
-      listen (~> 3.0)
-    kramdown (1.10.0)
-    liquid (3.0.6)
-    listen (3.0.6)
-      rb-fsevent (>= 0.9.3)
-      rb-inotify (>= 0.9.7)
-    mercenary (0.3.5)
-    rack (1.6.4)
-    rack-jekyll (0.4.5)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.14.0)
+    liquid (4.0.0)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    public_suffix (2.0.5)
+    rack (1.6.8)
+    rack-jekyll (0.5.0)
       jekyll (>= 1.3)
       listen (>= 1.3)
       rack (~> 1.5)
-    rb-fsevent (0.9.7)
-    rb-inotify (0.9.7)
-      ffi (>= 0.5.0)
-    rouge (1.10.1)
+    rb-fsevent (0.10.2)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (1.11.1)
     safe_yaml (1.0.4)
-    sass (3.4.21)
+    sass (3.5.1)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   jekyll
+  jekyll-polyglot!
   rack-jekyll
 
 BUNDLED WITH
-   1.11.2
+   1.15.3

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ them in the template.
 You can add `yml` files in the `_data` folder, and query the contents of
 these files using `site.data.{filename}`.
 
+## FAQ
+
+Check the [FAQ](FAQ.md)
+
 ### Example
 
 # About

--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,15 @@ permalink: /blog/:title
 # Build settings
 markdown: kramdown
 
+# Polyglot settings
+languages: ["en", "es"]
+default_lang: "en"
+exclude_from_localization: ["css", "js", "images"]
+parallel_localization: true
+
+plugins:
+  - jekyll-polyglot
+
 # SASS
 sass:
   style: compressed

--- a/_data/en/home.yml
+++ b/_data/en/home.yml
@@ -1,0 +1,2 @@
+lead_title: "Let's build something your users will ❤️ to use."
+lead_subtitle: "We are a software development agency that creates web and mobile experiences."

--- a/_data/es/home.yml
+++ b/_data/es/home.yml
@@ -1,0 +1,2 @@
+lead_title: "Let's build something your users will ❤️ to use."
+lead_subtitle: "We are a software development agency that creates web and mobile experiences."

--- a/_data/home.yml
+++ b/_data/home.yml
@@ -1,0 +1,1 @@
+lead_background_video: "/videos/hashlabs_branding_video_480p.mp4"


### PR DESCRIPTION
# Context

Aside from this also did:
- Added FAQ file
- Updated gem versions, this was done mostly to update jekyll version, so we are able to use new cool features like dynamic includes with variables `{% include {{ variable }} %}`

*NOTE: I added some data files for home page mostly as an example, notice these are 3 data files, one for english, one for spanish, and another for data that needs no translation, in this case a video. This is currently not being used, but added as a base example.*

## Links

- [Polyglot repository](https://github.com/untra/polyglot)
- [Polyglot page](http://polyglot.untra.io/)

## Media

http://g.recordit.co/y1xdsJVh95.gif