### PR TITLE
Prevent content to broke after resolution change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## Fixed
+* Prevent content to broke after resolution change ([@duranmla](https://github.com/duranmla))
+
 ## Changed
 * Clean base to start new design development ([@duranmla](https://github.com/duranmla))
 * README to include deploy staging info ([@duranmla](https://github.com/duranmla))

--- a/_sass/_layouts--global.scss
+++ b/_sass/_layouts--global.scss
@@ -6,10 +6,6 @@ body {
 .site {
   display: flex;
   flex-direction: column;
-
-  &-content {
-    flex: 1;
-  }
 }
 
 body {


### PR DESCRIPTION
# Context
While I haven't found why the rule on the `site-content` about `flex: 1` is causing the issue I have tested and whenever the resolution changes this rule makes the layout prone to be broken, so I will remove it cause even if it is used for the footer stick feature the footer is quite long to sort of overcome this issue. Feel free to restore/refactor this code whenever the cause gets clarified.

_Keep in mind this resolution changes may be possible if user simply change the orientation of the device so this may be an actual use case_

## Media

**With the rule**
![http://recordit.co/YDJ6d6c67j](http://recordit.co/YDJ6d6c67j.gif)

**Without the rule**
![http://recordit.co/0f36e13ZaN](http://recordit.co/0f36e13ZaN.gif)