### PR TITLE
Fix buttons width and testimony images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@
 * Webpack plugins for PurifyCSS and image optimizations ([@TheMightyPenguin])
 
 ### Fixed
-* caching on assets from CDN ([@carlows])
+* Fix buttons width ([@carlows])
+* Fix caching on assets from CDN ([@carlows])
 * Prevent content to broke after resolution change ([@duranmla])
 * button styles ([@carlows])
 * Corrected all links in home page ([@carlows])

--- a/_includes/footer-cta.html
+++ b/_includes/footer-cta.html
@@ -8,7 +8,7 @@
         <div class="footer-copy text-center text-md-left mt-5 mt-md-0">
           <h2 class="footer-copy-lead">{{ site.data.footer.lead }}</h2>
           <p class="footer-copy-sublead mt-3">{{ site.data.footer.sublead }}</p>
-          <a href="{{ site.data.footer.cta.url | prepend: site.baseurl }}" class="btn btn-primary btn-lg mt-4 mt-lg-5">{{ site.data.footer.cta.text }}</a>
+          <a href="{{ site.data.footer.cta.url | prepend: site.baseurl }}" class="btn btn-primary mt-4 mt-lg-5">{{ site.data.footer.cta.text }}</a>
         </div>
       </div>
     </div>

--- a/_includes/testimony.html
+++ b/_includes/testimony.html
@@ -8,7 +8,7 @@
     </blockquote>
   </div>
   <div class="testimony-author ml-4">
-    <img class="d-inline-block align-middle rounded-circle" src="{{ include.testimony.image | prepend: site.baseurl }}" srcset="{{ include.testimony.image | prepend: site.baseurl | srcset }}" alt="{{ include.testimony.author }}" />
+    <img class="d-inline-block align-middle rounded-circle testimony-author-image" src="{{ include.testimony.image | prepend: site.baseurl }}" srcset="{{ include.testimony.image | prepend: site.baseurl | srcset }}" alt="{{ include.testimony.author }}" />
     <p class="d-inline-block align-middle mb-0 ml-3 testimony-author-copy">
       <span>{{ include.testimony.author }}</span>
       <br />

--- a/_sass/_components--testimony.scss
+++ b/_sass/_components--testimony.scss
@@ -20,4 +20,8 @@
     font-size: $font-size-base * 0.875;
     max-width: 150px;
   }
+
+  &-author-image {
+    max-width: 60px;
+  }
 }

--- a/_sass/_objects--buttons.scss
+++ b/_sass/_objects--buttons.scss
@@ -36,7 +36,7 @@
 .btn {
   @include padding-y($spacer);
   cursor: pointer;
-  width: 180px;
+  min-width: 180px;
   font-weight: 600;
 
   @include media-breakpoint-up(lg) {
@@ -45,13 +45,13 @@
   }
 
   &-sm {
-    width: 140px;
+    min-width: 140px;
     @include padding-x($spacer*0.25);
   }
 }
 
 @include media-breakpoint-up(lg) {
   .btn, .btn-sm {
-    width: 215px;
+    min-width: 215px;
   }
 }


### PR DESCRIPTION
# Context

This PR fixes:

- Buttons width was fixed, I set this now with min-width so they can grow
- Testimony image now has a max-width so it doesn't break the layout

## Media

![image](https://user-images.githubusercontent.com/4183514/29049181-7cccad5c-7ba2-11e7-9f98-415ed9e38843.png)

![image](https://user-images.githubusercontent.com/4183514/29049191-8ded9f7e-7ba2-11e7-8785-68d27ca62a73.png)
