### PR TITLE
Metadata translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Bug with JS script of work page ([@TheMightyPenguin])
 
 ## Changed
+* Refactored files so page front-matter is translated ([@carlows])
 * Clean base to start new design development ([@duranmla])
 * README to include deploy staging info ([@duranmla])
 * Process animation trigger script ([@duranmla])

--- a/FAQ.md
+++ b/FAQ.md
@@ -140,4 +140,15 @@ E.G:
 <script defer src="https://code.jquery.com/jquery-3.1.1.min.js?external=true"></script>
 ```
 
+## How to add a title in a page?
+
+Just go to the folder where the page is located, for example for the index page it would be `/home`.
+
+Within the translated files `-en` and `-es`, add a title key with your title:
+
+```
+title: "Home" # Will be used as title for this page
+description: "Home description" # Will be used as description for this page
+```
+
 [polyglot]: https://github.com/untra/polyglot

--- a/_config.yml
+++ b/_config.yml
@@ -6,10 +6,8 @@
 # 'jekyll serve'. If you change this file, please restart the server process.
 
 # Site settings
-title: Hash Labs | Hassle free software engineering
 email: contact@hashlabs.com
-description: >
-  We are a digital agency that builds products for the web and mobile.
+description: We are a digital agency that builds products for the web and mobile.
 twitter_username: hashlabs
 github_username:  hashlabs
 thanks_url: https://www.hashlabs.com/thanks

--- a/_includes/pages/hire-us.html
+++ b/_includes/pages/hire-us.html
@@ -1,7 +1,3 @@
----
-layout: inverse-no-cta
----
-
 {% assign hire_us = site.data.hire_us %}
 
 {% comment %}

--- a/_includes/pages/home.html
+++ b/_includes/pages/home.html
@@ -1,7 +1,3 @@
----
-layout: inverse-with-sticky-navbar
----
-
 {% assign home=site.data.home %}
 {% assign first_testimony = home.testimonies[0] %}
 {% assign second_testimony = home.testimonies[1] %}

--- a/_includes/pages/process.html
+++ b/_includes/pages/process.html
@@ -1,7 +1,3 @@
----
-layout: default
----
-
 {% assign process=site.data.process %}
 
 <div id="process" class="process">

--- a/_includes/pages/services.html
+++ b/_includes/pages/services.html
@@ -1,7 +1,3 @@
----
-layout: inverse
----
-
 {% assign services=site.data.services %}
 
 <div id="services" class="services background-inverse">

--- a/_includes/pages/work.html
+++ b/_includes/pages/work.html
@@ -1,7 +1,3 @@
----
-layout: default
----
-
 {% assign work=site.data.work %}
 
 <div id="work" class="work">

--- a/hire-us/hire-us-en.html
+++ b/hire-us/hire-us-en.html
@@ -1,0 +1,8 @@
+---
+layout: inverse-no-cta
+lang: en
+permalink: /hire-us/
+title: "Hire Us"
+---
+
+{% include pages/hire-us.html %}

--- a/hire-us/hire-us-es.html
+++ b/hire-us/hire-us-es.html
@@ -1,0 +1,8 @@
+---
+layout: inverse-no-cta
+lang: es
+permalink: /hire-us/
+title: "Contratanos"
+---
+
+{% include pages/hire-us.html %}

--- a/home/home-en.html
+++ b/home/home-en.html
@@ -1,0 +1,8 @@
+---
+layout: inverse-with-sticky-navbar
+lang: en
+permalink: /
+title: "Home"
+---
+
+{% include pages/home.html %}

--- a/home/home-es.html
+++ b/home/home-es.html
@@ -1,0 +1,8 @@
+---
+layout: inverse-with-sticky-navbar
+lang: es
+permalink: /
+title: "Home"
+---
+
+{% include pages/home.html %}

--- a/process/process-en.html
+++ b/process/process-en.html
@@ -1,0 +1,8 @@
+---
+layout: default
+lang: en
+permalink: /process/
+title: "Our Process"
+---
+
+{% include pages/process.html %}

--- a/process/process-es.html
+++ b/process/process-es.html
@@ -1,0 +1,8 @@
+---
+layout: default
+lang: es
+permalink: /process/
+title: "Nuestro Proceso"
+---
+
+{% include pages/process.html %}

--- a/services/services-en.html
+++ b/services/services-en.html
@@ -1,0 +1,8 @@
+---
+layout: inverse
+lang: en
+permalink: /services/
+title: "Services"
+---
+
+{% include pages/services.html %}

--- a/services/services-es.html
+++ b/services/services-es.html
@@ -1,0 +1,8 @@
+---
+layout: inverse
+lang: es
+permalink: /services/
+title: "Servicios"
+---
+
+{% include pages/services.html %}

--- a/thanks/thanks-en.html
+++ b/thanks/thanks-en.html
@@ -1,0 +1,8 @@
+---
+layout: no-footer
+lang: en
+permalink: /thanks/
+title: "Thanks"
+---
+
+{% include thanks.html %}

--- a/thanks/thanks-es.html
+++ b/thanks/thanks-es.html
@@ -1,5 +1,8 @@
 ---
 layout: no-footer
+lang: es
+permalink: /thanks/
+title: "Gracias"
 ---
 
 {% include thanks.html %}

--- a/work/work-en.html
+++ b/work/work-en.html
@@ -1,0 +1,8 @@
+---
+layout: default
+lang: en
+permalink: /work/
+title: "Our work"
+---
+
+{% include pages/work.html %}

--- a/work/work-es.html
+++ b/work/work-es.html
@@ -1,0 +1,8 @@
+---
+layout: default
+lang: es
+permalink: /work/
+title: "Nuestro trabajo"
+---
+
+{% include pages/work.html %}


### PR DESCRIPTION
# Context

This PR refactors pages so the front-matter can be translated, this way things like title and description can change depending on the language.

For example, setting title and description in `/services/services-es.html` like this:

```
title: 'Servicios'
description: 'Hello world'
```

Results in:

![image](https://user-images.githubusercontent.com/4183514/29093115-aab65e0c-7c56-11e7-9355-779a6ce33509.png)

There's also no default title anymore, title needs to be added to all pages (I added a default for both languages)